### PR TITLE
FEAT:  Custom Auth Guard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,13 +22,20 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+	// spring web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	// spring data jpa
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+	// JWT
+	implementation 'com.auth0:java-jwt:4.4.0'
+	// for dev.
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-
+	// DB connection
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'com.h2database:h2'
 

--- a/src/main/java/com/ticketwar/ticketwar/auth/domain/jwt/JwtConfigure.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/domain/jwt/JwtConfigure.java
@@ -1,0 +1,21 @@
+package com.ticketwar.ticketwar.auth.domain.jwt;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtConfigure {
+  @Value("${jwt.data.name:USER_DATA}")
+  private String dataName;
+
+  @Value("${jwt.secret}")
+  private String secret;
+
+  public String getDataName() {
+    return dataName;
+  }
+
+  public String getSecret() {
+    return secret;
+  }
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/domain/jwt/JwtData.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/domain/jwt/JwtData.java
@@ -1,0 +1,41 @@
+package com.ticketwar.ticketwar.auth.domain.jwt;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.ToString;
+
+@ToString
+public class JwtData {
+
+  private Long id;
+  private String nickname;
+  private String email;
+  private String role;
+
+  public JwtData() {
+  }
+
+  @Builder
+  public JwtData(@NonNull Long id, @NonNull String nickname, @NonNull String email, @NonNull String role) {
+    this.id = id;
+    this.nickname = nickname;
+    this.email = email;
+    this.role = role;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getNickname() {
+    return nickname;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getRole() {
+    return role;
+  }
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/domain/jwt/JwtGuard.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/domain/jwt/JwtGuard.java
@@ -1,0 +1,12 @@
+package com.ticketwar.ticketwar.auth.domain.jwt;
+
+import com.ticketwar.ticketwar.auth.pass.AuthGuard;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtGuard extends AuthGuard {
+  public JwtGuard(@Autowired JwtStrategy strategy) {
+    super(strategy);
+  }
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/domain/jwt/JwtStrategy.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/domain/jwt/JwtStrategy.java
@@ -1,0 +1,21 @@
+package com.ticketwar.ticketwar.auth.domain.jwt;
+
+import com.ticketwar.ticketwar.auth.pass.AuthStrategy;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtStrategy implements AuthStrategy {
+  @Autowired
+  private JwtConfigure jwtConfigure;
+  @Autowired
+  private JwtUtil jwtUtil;
+
+  @Override
+  public void check(HttpServletRequest request, String... args) {
+    final JwtData jwtData = jwtUtil.verifyTokenFromRequestAuthorizationHeader(request);
+    request.setAttribute(jwtConfigure.getDataName(), jwtData);
+  }
+  
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/domain/jwt/JwtUtil.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/domain/jwt/JwtUtil.java
@@ -1,0 +1,50 @@
+package com.ticketwar.ticketwar.auth.domain.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+  private final String BEARER = "BEARER ";
+  @Autowired
+  private JwtConfigure jwtConfigure;
+
+  /**
+   * Verify Authorization header's bearer token.
+   * <p>
+   * if fails, it throws RuntimeException.
+   *
+   * @param request
+   * @return
+   */
+  public JwtData verifyTokenFromRequestAuthorizationHeader(HttpServletRequest request) {
+    final String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION).substring(BEARER.length());
+    final Algorithm algorithm = Algorithm.HMAC256(jwtConfigure.getSecret());
+    final JWTVerifier jwtVerifier = JWT.require(algorithm).build();
+    final DecodedJWT decodedJWT = jwtVerifier.verify(bearerToken);
+
+    return getJwtDataFromDecodedJwt(decodedJWT);
+  }
+
+  // 해당 부분에 대해서 조금 더 깔끔하게 처리를 할 수 있으면 좋겠음.
+  private JwtData getJwtDataFromDecodedJwt(DecodedJWT decodedJWT) {
+    final Claim id = decodedJWT.getClaim("id");
+    final Claim email = decodedJWT.getClaim("email");
+    final Claim nickname = decodedJWT.getClaim("nickname");
+    final Claim role = decodedJWT.getClaim("role");
+
+    return JwtData.builder()
+        .id(id.asLong())
+        .email(email.asString())
+        .nickname(nickname.asString())
+        .role(role.asString())
+        .build();
+  }
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/domain/role/RoleGuard.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/domain/role/RoleGuard.java
@@ -1,0 +1,12 @@
+package com.ticketwar.ticketwar.auth.domain.role;
+
+import com.ticketwar.ticketwar.auth.pass.AuthGuard;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoleGuard extends AuthGuard {
+  public RoleGuard(@Autowired RoleStrategy strategy) {
+    super(strategy);
+  }
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/domain/role/RoleStrategy.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/domain/role/RoleStrategy.java
@@ -1,0 +1,55 @@
+package com.ticketwar.ticketwar.auth.domain.role;
+
+import com.ticketwar.ticketwar.auth.domain.jwt.JwtConfigure;
+import com.ticketwar.ticketwar.auth.domain.jwt.JwtData;
+import com.ticketwar.ticketwar.auth.domain.jwt.JwtUtil;
+import com.ticketwar.ticketwar.auth.pass.AuthStrategy;
+import com.ticketwar.ticketwar.exception.CustomException;
+import com.ticketwar.ticketwar.exception.ExceptionStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoleStrategy implements AuthStrategy {
+
+  @Autowired
+  private JwtConfigure jwtConfigure;
+  @Autowired
+  private JwtUtil jwtUtil;
+
+  /**
+   * @param request
+   * @param permittedRoles
+   */
+  @Override
+  public void check(HttpServletRequest request, String[] permittedRoles) {
+    final JwtData jwtData = getJwtData(request);
+    final String role = jwtData.getRole();
+    if (isPermittedRole(role, permittedRoles) == false) {
+      throw new CustomException(ExceptionStatus.UNAUTHORIZED_USER);
+    }
+  }
+
+  private JwtData getJwtData(HttpServletRequest request) throws RuntimeException {
+    final String dataName = jwtConfigure.getDataName();
+    JwtData jwtData = (JwtData) request.getAttribute(dataName);
+
+    if (jwtData == null) {
+      jwtData = jwtUtil.verifyTokenFromRequestAuthorizationHeader(request);
+      request.setAttribute(dataName, jwtData);
+    }
+    return jwtData;
+  }
+
+
+  private boolean isPermittedRole(String role, String[] permittedRoles) {
+    for (String permitted : permittedRoles) {
+      System.out.println(permitted);
+      if (permitted.equals(role)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/pass/AuthGuard.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/pass/AuthGuard.java
@@ -1,0 +1,28 @@
+package com.ticketwar.ticketwar.auth.pass;
+
+import com.ticketwar.ticketwar.exception.CustomException;
+import com.ticketwar.ticketwar.exception.ExceptionStatus;
+import jakarta.servlet.http.HttpServletRequest;
+
+public abstract class AuthGuard {
+  private AuthStrategy authStrategy;
+
+  /**
+   * 상속받은 클래스는 반드시 AuthStrategy를 지정해야합니다.
+   *
+   * @param authStrategy
+   */
+  public AuthGuard(AuthStrategy authStrategy) {
+    this.authStrategy = authStrategy;
+  }
+
+  public final void check(HttpServletRequest request, String... args) {
+    try {
+      authStrategy.check(request, args);
+    } catch (CustomException customException) {
+      throw customException;
+    } catch (RuntimeException e) {
+      throw new CustomException(ExceptionStatus.UNAUTHORIZED_USER);
+    }
+  }
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/pass/AuthStrategy.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/pass/AuthStrategy.java
@@ -1,0 +1,14 @@
+package com.ticketwar.ticketwar.auth.pass;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface AuthStrategy {
+
+  /**
+   * Check method는 해당 Auth 작업에 대한 전략을 수행합니다. 만약, 검증 과정에서 실패할 경우 Error를 throw 합니다. 해당 Error는
+   * Exception Handler 에서 처리할 수 있습니다.
+   *
+   * @param request
+   */
+  public void check(HttpServletRequest request, String... args);
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/pass/Guard.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/pass/Guard.java
@@ -1,0 +1,15 @@
+package com.ticketwar.ticketwar.auth.pass;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Guard {
+
+  Class value();
+
+  String[] args() default {};
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/pass/GuardAspect.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/pass/GuardAspect.java
@@ -1,0 +1,40 @@
+package com.ticketwar.ticketwar.auth.pass;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Aspect
+@Component
+public class GuardAspect {
+
+  @Autowired
+  private GuardResolver guardResolver;
+
+  @Before("@annotation(useGuards)")
+  public void handleUseGuards(UseGuards useGuards) {
+    final HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder
+        .currentRequestAttributes()).getRequest();
+    final List<Guard> guards = Arrays.stream(useGuards.value()).toList();
+    for (Guard guard : guards) {
+      AuthGuard authGuard = guardResolver.getGuard(guard.value().getSimpleName());
+      authGuard.check(request, guard.args());
+    }
+  }
+
+  @Before("@annotation(guard)")
+  public void handleGuard(Guard guard) {
+    final HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder
+        .currentRequestAttributes()).getRequest();
+    final AuthGuard authGuard =
+        guardResolver.getGuard(guard.value().getSimpleName());
+    authGuard.check(request, guard.args());
+  }
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/pass/GuardResolver.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/pass/GuardResolver.java
@@ -1,0 +1,28 @@
+package com.ticketwar.ticketwar.auth.pass;
+
+import lombok.NonNull;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class GuardResolver {
+
+  private final Map<String, AuthGuard> guards;
+
+  public GuardResolver(List<AuthGuard> guards) {
+    this.guards = guards.stream()
+        .collect(
+            Collectors.toMap(
+                g -> g.getClass().getSimpleName(),
+                Function.identity()
+            ));
+  }
+
+  public AuthGuard getGuard(@NonNull String guardName) {
+    return this.guards.get(guardName);
+  }
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/pass/UseGuards.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/pass/UseGuards.java
@@ -1,0 +1,16 @@
+package com.ticketwar.ticketwar.auth.pass;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * UseGuards
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UseGuards {
+
+  Guard[] value();
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/pass/UserData.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/pass/UserData.java
@@ -1,0 +1,20 @@
+package com.ticketwar.ticketwar.auth.pass;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * UserData 는 Request 에서 가져올 Attribute 를 지정할 수 있습니다.
+ * <p>
+ * 기본 값으로 해당 Annotation 은 "UserData" 를 사용합니다.
+ *
+ * @Warn 반드시 알맞는 타입의 Parameter를 사용해야합니다.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserData {
+
+  public String value() default "USER_DATA";
+}

--- a/src/main/java/com/ticketwar/ticketwar/auth/pass/UserDataAspect.java
+++ b/src/main/java/com/ticketwar/ticketwar/auth/pass/UserDataAspect.java
@@ -1,0 +1,50 @@
+package com.ticketwar.ticketwar.auth.pass;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+@Aspect
+@Component
+public class UserDataAspect {
+
+  /**
+   * TokenData annotation 을 적용한 Parameter 에 대해서 Request의 TokenData Attribute 를 가져옵니다. Pointcut :
+   * method(params.., @TokenData(Type data), params..)
+   * <p>
+   * TokenData 의 경우 v
+   *
+   * @param joinPoint
+   * @return
+   * @throws Throwable
+   */
+  @Around("execution(* *(.., @com.ticketwar.ticketwar.auth.pass.UserData (*), ..))")
+  public Object handleUserData(ProceedingJoinPoint joinPoint)
+      throws Throwable {
+    final Signature signature = joinPoint.getSignature();
+    final MethodSignature methodSignature = (MethodSignature) signature;
+    final Method method = methodSignature.getMethod();
+    final Parameter[] parameters = method.getParameters();
+    final Object args[] = joinPoint.getArgs();
+    final HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder
+        .currentRequestAttributes()).getRequest();
+
+    for (int idx = 0; idx < parameters.length; ++idx) {
+      UserData userData = parameters[idx].getAnnotation(UserData.class);
+      if (userData != null) {
+        args[idx] = request.getAttribute(userData.value());
+        break;
+      }
+    }
+    return joinPoint.proceed(args);
+  }
+}

--- a/src/main/java/com/ticketwar/ticketwar/exception/CustomException.java
+++ b/src/main/java/com/ticketwar/ticketwar/exception/CustomException.java
@@ -1,6 +1,9 @@
 package com.ticketwar.ticketwar.exception;
 
+import java.util.function.Supplier;
+
 public class CustomException extends RuntimeException {
+
   private final ExceptionStatus exceptionStatus;
 
   public CustomException(ExceptionStatus exceptionStatus) {
@@ -14,5 +17,9 @@ public class CustomException extends RuntimeException {
   @Override
   public String getMessage() {
     return exceptionStatus.getMsg();
+  }
+
+  public static Supplier<CustomException> build(ExceptionStatus exceptionStatus) {
+    return () -> new CustomException(exceptionStatus);
   }
 }

--- a/src/main/java/com/ticketwar/ticketwar/exception/ExceptionStatus.java
+++ b/src/main/java/com/ticketwar/ticketwar/exception/ExceptionStatus.java
@@ -5,7 +5,14 @@ import org.springframework.http.HttpStatus;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExceptionStatus {
+  // user
+  // Not found
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+  // Bad Request
+  DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
+  DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다."),
+  UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "허가되지 않은 유저입니다."),
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다."),
   ;
 
   private final int code;

--- a/src/main/java/com/ticketwar/ticketwar/user/controller/UserController.java
+++ b/src/main/java/com/ticketwar/ticketwar/user/controller/UserController.java
@@ -40,20 +40,19 @@ public class UserController {
     return ResponseEntity.created(location).build();
   }
 
-  @PatchMapping("/{id}")
-  @Guard(value = RoleGuard.class, args = {"ADMIN"})
-  public User update(@PathVariable("id") Long id, @RequestBody UserReqDto userReqDto)
-      throws BadRequestException {
-    return userService.update(id, userReqDto);
-  }
-
-
-  @GetMapping("/{id}")
+  @GetMapping("/me")
   @Guard(JwtGuard.class)
   public ResponseEntity<UserResDto> getById(@UserData JwtData jwtData)
       throws NotFoundException {
     final Long id = jwtData.getId();
     return ResponseEntity.ok(userService.getById(id));
+  }
+  
+  @PatchMapping("/{id}")
+  @Guard(value = RoleGuard.class, args = {"ADMIN"})
+  public User update(@PathVariable("id") Long id, @RequestBody UserReqDto userReqDto)
+      throws BadRequestException {
+    return userService.update(id, userReqDto);
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/ticketwar/ticketwar/user/controller/UserController.java
+++ b/src/main/java/com/ticketwar/ticketwar/user/controller/UserController.java
@@ -1,22 +1,22 @@
 package com.ticketwar.ticketwar.user.controller;
 
+import com.ticketwar.ticketwar.auth.domain.jwt.JwtData;
+import com.ticketwar.ticketwar.auth.domain.jwt.JwtGuard;
+import com.ticketwar.ticketwar.auth.domain.role.RoleGuard;
+import com.ticketwar.ticketwar.auth.pass.Guard;
+import com.ticketwar.ticketwar.auth.pass.UserData;
 import com.ticketwar.ticketwar.user.dto.UserReqDto;
 import com.ticketwar.ticketwar.user.dto.UserResDto;
 import com.ticketwar.ticketwar.user.entity.User;
 import com.ticketwar.ticketwar.user.service.UserService;
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.BadRequestException;
 import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
 
 /**
  * Customer 관련 정보에 대한 Rest Controller
@@ -41,24 +41,39 @@ public class UserController {
   }
 
   @PatchMapping("/{id}")
+  @Guard(value = RoleGuard.class, args = {"ADMIN"})
   public User update(@PathVariable("id") Long id, @RequestBody UserReqDto userReqDto)
       throws BadRequestException {
     return userService.update(id, userReqDto);
   }
 
+
   @GetMapping("/{id}")
-  public ResponseEntity<UserResDto> getById(@PathVariable("id") Long id)
+  @Guard(JwtGuard.class)
+  public ResponseEntity<UserResDto> getById(@UserData JwtData jwtData)
+      throws NotFoundException {
+    final Long id = jwtData.getId();
+    return ResponseEntity.ok(userService.getById(id));
+  }
+
+  @GetMapping("/{id}")
+  @Guard(value = RoleGuard.class, args = {"ADMIN"})
+  public ResponseEntity<UserResDto> getById(
+      @PathVariable("id") Long id
+  )
       throws NotFoundException {
     return ResponseEntity.ok(userService.getById(id));
   }
 
   @GetMapping("/nickname/{nickname}")
+  @Guard(value = RoleGuard.class, args = {"ADMIN"})
   public UserResDto getByNickname(@PathVariable("nickname") String nickname)
       throws NotFoundException {
     return userService.getByNickname(nickname);
   }
 
   @GetMapping("/email/{email}")
+  @Guard(value = RoleGuard.class, args = {"ADMIN"})
   public UserResDto getByEmail(@PathVariable("email") String email)
       throws NotFoundException {
     return userService.getByEmail(email);

--- a/src/main/java/com/ticketwar/ticketwar/user/entity/User.java
+++ b/src/main/java/com/ticketwar/ticketwar/user/entity/User.java
@@ -2,21 +2,11 @@ package com.ticketwar.ticketwar.user.entity;
 
 import com.ticketwar.ticketwar.common.entity.trackable.CreatedAndUpdatedTimeTrackable;
 import com.ticketwar.ticketwar.order.entity.Order;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
 
 @Entity
 @Table(name = "USERS")
@@ -38,6 +28,9 @@ public class User extends CreatedAndUpdatedTimeTrackable {
   @Column(name = "password", length = 20, nullable = false)
   private String password; // have to be encrypted
 
+  @Column(name = "role", nullable = false)
+  private UserRole role;
+
   @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
   private List<Order> orders;
 
@@ -47,12 +40,14 @@ public class User extends CreatedAndUpdatedTimeTrackable {
       @NonNull String nickname,
       @NonNull String email,
       @NonNull String password,
+      UserRole role,
       List<Order> orders) {
     setId(id);
     setNickname(nickname);
     setEmail(email);
     setPassword(password);
     setOrders(orders);
+    setRole(role != null ? role : UserRole.USER);
   }
 
   public void setId(Long id) {
@@ -69,6 +64,10 @@ public class User extends CreatedAndUpdatedTimeTrackable {
 
   public void setPassword(@NonNull String password) {
     this.password = password;
+  }
+
+  public void setRole(@NonNull UserRole role) {
+    this.role = role;
   }
 
   public void setOrders(List<Order> orders) {

--- a/src/main/java/com/ticketwar/ticketwar/user/entity/UserRole.java
+++ b/src/main/java/com/ticketwar/ticketwar/user/entity/UserRole.java
@@ -1,0 +1,8 @@
+package com.ticketwar.ticketwar.user.entity;
+
+public enum UserRole {
+  USER,
+  ADMIN,
+  ;
+  
+}

--- a/src/main/java/com/ticketwar/ticketwar/user/service/UserService.java
+++ b/src/main/java/com/ticketwar/ticketwar/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.ticketwar.ticketwar.user.service;
 
+import com.ticketwar.ticketwar.exception.CustomException;
+import com.ticketwar.ticketwar.exception.ExceptionStatus;
 import com.ticketwar.ticketwar.user.dto.UserReqDto;
 import com.ticketwar.ticketwar.user.dto.UserResDto;
 import com.ticketwar.ticketwar.user.entity.User;
@@ -38,10 +40,10 @@ public class UserService {
     final String email = userReqDto.getEmail();
 
     if (userQueryService.isDuplicateNickname(nickname)) {
-      throw new BadRequestException("Duplicated nickname");
+      throw new CustomException(ExceptionStatus.DUPLICATED_NICKNAME);
     }
     if (userQueryService.isDuplicateEmail(email)) {
-      throw new BadRequestException("Duplicated email");
+      throw new CustomException(ExceptionStatus.DUPLICATED_EMAIL);
     }
     return userRepository.save(userReqDto.toEntity());
   }
@@ -64,10 +66,10 @@ public class UserService {
     final String updateEmail = userReqDto.getEmail();
 
     if (userQueryService.isDuplicateNickname(id, updateNickname)) {
-      throw new BadRequestException("Duplicated nickname");
+      throw new CustomException(ExceptionStatus.DUPLICATED_NICKNAME);
     }
     if (userQueryService.isDuplicateEmail(id, updateEmail)) {
-      throw new BadRequestException("Duplicated email");
+      throw new CustomException(ExceptionStatus.DUPLICATED_EMAIL);
     }
     user.setNickname(updateNickname);
     user.setEmail(updateEmail);
@@ -81,10 +83,12 @@ public class UserService {
    * @return
    * @throws NotFoundException
    */
-  public UserResDto getById(Long id) throws NotFoundException {
+  public UserResDto getById(Long id)
+      throws NotFoundException {
+
     return userRepository.findById(id)
                          .map(userMapper::mapToResDto)
-                         .orElseThrow(NotFoundException::new);
+                         .orElseThrow(CustomException.build(ExceptionStatus.USER_NOT_FOUND));
   }
 
   /**
@@ -97,7 +101,7 @@ public class UserService {
   public UserResDto getByNickname(String nickname) throws NotFoundException {
     return userRepository.findByNickname(nickname)
                          .map(userMapper::mapToResDto)
-                         .orElseThrow(NotFoundException::new);
+                         .orElseThrow(CustomException.build(ExceptionStatus.USER_NOT_FOUND));
   }
 
   /**
@@ -110,6 +114,6 @@ public class UserService {
   public UserResDto getByEmail(String email) throws NotFoundException {
     return userRepository.findByEmail(email)
                          .map(userMapper::mapToResDto)
-                         .orElseThrow(NotFoundException::new);
+                         .orElseThrow(CustomException.build(ExceptionStatus.USER_NOT_FOUND));
   }
 }

--- a/src/main/resources/yaml/local.yml
+++ b/src/main/resources/yaml/local.yml
@@ -23,3 +23,6 @@ spring:
     driver-class-name: org.h2.Driver
     username: root
     password: # enter your root password if set.
+
+jwt:
+  secret: "test"

--- a/src/test/java/com/ticketwar/ticketwar/user/service/UserServiceTest.java
+++ b/src/test/java/com/ticketwar/ticketwar/user/service/UserServiceTest.java
@@ -1,18 +1,13 @@
 package com.ticketwar.ticketwar.user.service;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-
+import com.ticketwar.ticketwar.exception.CustomException;
+import com.ticketwar.ticketwar.exception.ExceptionStatus;
 import com.ticketwar.ticketwar.user.dto.UserReqDto;
 import com.ticketwar.ticketwar.user.dto.UserResDto;
 import com.ticketwar.ticketwar.user.entity.User;
 import com.ticketwar.ticketwar.user.repository.UserRepository;
 import com.ticketwar.ticketwar.user.utils.UserMapper;
 import jakarta.transaction.Transactional;
-import java.util.Optional;
-import org.apache.coyote.BadRequestException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -24,7 +19,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -53,16 +52,16 @@ class UserServiceTest {
       String email = "sungjpar@student.42seoul.kr";
       Long id = 1L;
       UserReqDto request = UserReqDto.builder()
-                                     .nickname(nickname)
-                                     .email(email)
-                                     .password("password")
-                                     .build();
+          .nickname(nickname)
+          .email(email)
+          .password("password")
+          .build();
       User expect = User.builder()
-                        .id(1L)
-                        .nickname(nickname)
-                        .email(email)
-                        .password("password")
-                        .build();
+          .id(1L)
+          .nickname(nickname)
+          .email(email)
+          .password("password")
+          .build();
       BDDMockito.given(queryService.isDuplicateNickname(any(String.class))).willReturn(false);
       BDDMockito.given(queryService.isDuplicateEmail(any(String.class))).willReturn(false);
       BDDMockito.given(repository.save(any(User.class))).willReturn(expect);
@@ -76,27 +75,27 @@ class UserServiceTest {
     public void test_sign_up_duplicate_nickname() {
       // given
       UserReqDto request = UserReqDto.builder()
-                                     .nickname("sungjpar")
-                                     .email("email@email.com")
-                                     .password("password")
-                                     .build();
+          .nickname("sungjpar")
+          .email("email@email.com")
+          .password("password")
+          .build();
       BDDMockito.given(queryService.isDuplicateNickname(any(String.class))).willReturn(true);
       // when, then
-      assertThrows(BadRequestException.class, () -> service.signUp(request));
+      assertThrows(CustomException.class, () -> service.signUp(request), ExceptionStatus.DUPLICATED_NICKNAME.getMsg());
     }
 
     @DisplayName("실패 - 이메일 중복")
     @Test
     public void test_sign_up_duplicate_email() {      // given
       UserReqDto request = UserReqDto.builder()
-                                     .nickname("sungjpar")
-                                     .email("email@email.com")
-                                     .password("password")
-                                     .build();
+          .nickname("sungjpar")
+          .email("email@email.com")
+          .password("password")
+          .build();
       BDDMockito.given(queryService.isDuplicateNickname(any(String.class))).willReturn(false);
       BDDMockito.given(queryService.isDuplicateEmail(any(String.class))).willReturn(true);
       // when, then
-      assertThrows(BadRequestException.class, () -> service.signUp(request));
+      assertThrows(CustomException.class, () -> service.signUp(request), ExceptionStatus.DUPLICATED_EMAIL.getMsg());
     }
 
   }
@@ -113,21 +112,21 @@ class UserServiceTest {
       String email = "sungjpar@student.42seoul.kr";
       Long id = 1L;
       UserReqDto request = UserReqDto.builder()
-                                     .nickname(nickname)
-                                     .email(email)
-                                     .password("password")
-                                     .build();
+          .nickname(nickname)
+          .email(email)
+          .password("password")
+          .build();
       User expect = User.builder()
-                        .id(1L)
-                        .nickname(nickname)
-                        .email(email)
-                        .password("password")
-                        .build();
+          .id(1L)
+          .nickname(nickname)
+          .email(email)
+          .password("password")
+          .build();
       BDDMockito.given(repository.findById(any(Long.class))).willReturn(Optional.of(expect));
       BDDMockito.given(queryService.isDuplicateNickname(any(Long.class), any(String.class)))
-                .willReturn(false);
+          .willReturn(false);
       BDDMockito.given(queryService.isDuplicateEmail(any(Long.class), any(String.class)))
-                .willReturn(false);
+          .willReturn(false);
       BDDMockito.given(repository.save(any(User.class))).willReturn(expect);
       // when
       User updatedUser = assertDoesNotThrow(() -> service.update(1L, request));
@@ -143,24 +142,24 @@ class UserServiceTest {
       String email = "sungjpar@student.42seoul.kr";
       Long id = 1L;
       UserReqDto request = UserReqDto.builder()
-                                     .nickname(nickname)
-                                     .email(email)
-                                     .password("password")
-                                     .build();
+          .nickname(nickname)
+          .email(email)
+          .password("password")
+          .build();
       User expect = User.builder()
-                        .id(1L)
-                        .nickname(nickname)
-                        .email(email)
-                        .password("password")
-                        .build();
+          .id(1L)
+          .nickname(nickname)
+          .email(email)
+          .password("password")
+          .build();
       BDDMockito.given(repository.findById(any(Long.class))).willReturn(Optional.of(expect));
       BDDMockito.given(queryService.isDuplicateNickname(any(Long.class), any(String.class)))
-                .willReturn(true);
+          .willReturn(true);
       BDDMockito.given(queryService.isDuplicateEmail(any(Long.class), any(String.class)))
-                .willReturn(false);
+          .willReturn(false);
       BDDMockito.given(repository.save(any(User.class))).willReturn(expect);
       // when then
-      assertThrows(BadRequestException.class, () -> service.update(1L, request));
+      assertThrows(CustomException.class, () -> service.update(1L, request), ExceptionStatus.DUPLICATED_NICKNAME.getMsg());
     }
 
     @Test
@@ -171,24 +170,24 @@ class UserServiceTest {
       String email = "sungjpar@student.42seoul.kr";
       Long id = 1L;
       UserReqDto request = UserReqDto.builder()
-                                     .nickname(nickname)
-                                     .email(email)
-                                     .password("password")
-                                     .build();
+          .nickname(nickname)
+          .email(email)
+          .password("password")
+          .build();
       User expect = User.builder()
-                        .id(1L)
-                        .nickname(nickname)
-                        .email(email)
-                        .password("password")
-                        .build();
+          .id(1L)
+          .nickname(nickname)
+          .email(email)
+          .password("password")
+          .build();
       BDDMockito.given(repository.findById(any(Long.class))).willReturn(Optional.of(expect));
       BDDMockito.given(queryService.isDuplicateNickname(any(Long.class), any(String.class)))
-                .willReturn(false);
+          .willReturn(false);
       BDDMockito.given(queryService.isDuplicateEmail(any(Long.class), any(String.class)))
-                .willReturn(true);
+          .willReturn(true);
       BDDMockito.given(repository.save(any(User.class))).willReturn(expect);
       // when then
-      assertThrows(BadRequestException.class, () -> service.update(1L, request));
+      assertThrows(CustomException.class, () -> service.update(1L, request), ExceptionStatus.DUPLICATED_EMAIL.getMsg());
     }
 
   }
@@ -202,11 +201,11 @@ class UserServiceTest {
     @BeforeEach
     public void setUp() {
       user = User.builder()
-                 .id(1L)
-                 .nickname("test")
-                 .email("test@test.com")
-                 .password("password")
-                 .build();
+          .id(1L)
+          .nickname("test")
+          .email("test@test.com")
+          .password("password")
+          .build();
     }
 
     @Test
@@ -215,10 +214,10 @@ class UserServiceTest {
       // given
       Long id = 1L;
       UserResDto expected = UserResDto.builder()
-                                      .id(user.getId())
-                                      .nickname(user.getNickname())
-                                      .email(user.getEmail())
-                                      .build();
+          .id(user.getId())
+          .nickname(user.getNickname())
+          .email(user.getEmail())
+          .build();
       BDDMockito.given(repository.findById(any(Long.class))).willReturn(Optional.of(user));
       BDDMockito.given(mapper.mapToResDto(any(User.class))).willReturn(expected);
       // when
@@ -233,14 +232,14 @@ class UserServiceTest {
       // given
       Long id = 1L;
       UserResDto expected = UserResDto.builder()
-                                      .id(user.getId())
-                                      .nickname(user.getNickname())
-                                      .email(user.getEmail())
-                                      .build();
+          .id(user.getId())
+          .nickname(user.getNickname())
+          .email(user.getEmail())
+          .build();
       BDDMockito.given(repository.findById(any(Long.class))).willReturn(Optional.empty());
       BDDMockito.given(mapper.mapToResDto(any(User.class))).willReturn(expected);
       // when
-      assertThrows(NotFoundException.class, () -> service.getById(999L));
+      assertThrows(CustomException.class, () -> service.getById(999L), ExceptionStatus.USER_NOT_FOUND.getMsg());
     }
   }
 
@@ -253,11 +252,11 @@ class UserServiceTest {
     @BeforeEach
     public void setUp() {
       user = User.builder()
-                 .id(1L)
-                 .nickname("test")
-                 .email("test@test.com")
-                 .password("password")
-                 .build();
+          .id(1L)
+          .nickname("test")
+          .email("test@test.com")
+          .password("password")
+          .build();
     }
 
     @Test
@@ -266,12 +265,12 @@ class UserServiceTest {
       // given
       Long id = 1L;
       UserResDto expected = UserResDto.builder()
-                                      .id(user.getId())
-                                      .nickname(user.getNickname())
-                                      .email(user.getEmail())
-                                      .build();
+          .id(user.getId())
+          .nickname(user.getNickname())
+          .email(user.getEmail())
+          .build();
       BDDMockito.given(repository.findByNickname(any(String.class)))
-                .willReturn(Optional.of(user));
+          .willReturn(Optional.of(user));
       BDDMockito.given(mapper.mapToResDto(any(User.class))).willReturn(expected);
       // when
       UserResDto result = assertDoesNotThrow(
@@ -286,14 +285,14 @@ class UserServiceTest {
       // given
       Long id = 1L;
       UserResDto expected = UserResDto.builder()
-                                      .id(user.getId())
-                                      .nickname(user.getNickname())
-                                      .email(user.getEmail())
-                                      .build();
+          .id(user.getId())
+          .nickname(user.getNickname())
+          .email(user.getEmail())
+          .build();
       BDDMockito.given(repository.findByNickname(any(String.class))).willReturn(Optional.empty());
       BDDMockito.given(mapper.mapToResDto(any(User.class))).willReturn(expected);
       // when
-      assertThrows(NotFoundException.class, () -> service.getByNickname("None"));
+      assertThrows(CustomException.class, () -> service.getByNickname("None"), ExceptionStatus.USER_NOT_FOUND.getMsg());
     }
   }
 
@@ -306,11 +305,11 @@ class UserServiceTest {
     @BeforeEach
     public void setUp() {
       user = User.builder()
-                 .id(1L)
-                 .nickname("test")
-                 .email("test@test.com")
-                 .password("password")
-                 .build();
+          .id(1L)
+          .nickname("test")
+          .email("test@test.com")
+          .password("password")
+          .build();
     }
 
     @Test
@@ -319,12 +318,12 @@ class UserServiceTest {
       // given
       Long id = 1L;
       UserResDto expected = UserResDto.builder()
-                                      .id(user.getId())
-                                      .nickname(user.getNickname())
-                                      .email(user.getEmail())
-                                      .build();
+          .id(user.getId())
+          .nickname(user.getNickname())
+          .email(user.getEmail())
+          .build();
       BDDMockito.given(repository.findByEmail(any(String.class)))
-                .willReturn(Optional.of(user));
+          .willReturn(Optional.of(user));
       BDDMockito.given(mapper.mapToResDto(any(User.class))).willReturn(expected);
       // when
       UserResDto result = assertDoesNotThrow(
@@ -339,14 +338,14 @@ class UserServiceTest {
       // given
       Long id = 1L;
       UserResDto expected = UserResDto.builder()
-                                      .id(user.getId())
-                                      .nickname(user.getNickname())
-                                      .email(user.getEmail())
-                                      .build();
+          .id(user.getId())
+          .nickname(user.getNickname())
+          .email(user.getEmail())
+          .build();
       BDDMockito.given(repository.findByEmail(any(String.class))).willReturn(Optional.empty());
       BDDMockito.given(mapper.mapToResDto(any(User.class))).willReturn(expected);
       // when
-      assertThrows(NotFoundException.class, () -> service.getByEmail("None"));
+      assertThrows(CustomException.class, () -> service.getByEmail("None"), ExceptionStatus.USER_NOT_FOUND.getMsg());
     }
   }
 }


### PR DESCRIPTION
# Auth System (auth-pass)
![image](https://github.com/TicketWar/backend/assets/81505228/55340598-c415-4429-af31-08c429e5c5fe)
## 작업 내용
- auth-pass 작업 이전 custom exception 부분 일부 수정
- controller 에서 method 실행 전 인증 과정을 위한 도우미 프레임워크(?) 개발
- 예시로 JwtGuard - Strategy / RoleGuard - Strategy 개발 및 UserController 적용

## 특징
- 나름 직관적이고, 쉽게 인증 과정을 처리할 수 있습니다.
  - Controller 의 method 실행 이전에 처리할 로직에 대한 장치이므로, Spring Security 만큼의 학습이 필요하지 않습니다.
  - 단순히 Strategy 의 개발에 집중함으로써, 문제를 해결할 수 있습니다.
- 다만 안정성면에서 보장되어있지 않다는 것, Spring Security 만큼 풍부한 솔루션은 존재하지 않습니다.

## AuthGuard
- Controller의 method를 대상으로 Request 처리 이전에 intercept하여 실행할 로직을 결정하는 시스템이다. 해당 시스템은 `@UseGuards`, `@Guard` 를 통해서 `Guard`를 선택하여 method에 적용할 수 있으며, 로직의 정의는 `Strategy` 를 통해 수행한다.
### @Guard
- Controller 에서 사용자가 request 이전에 인증 / 인가 과정에 사용할 `Guard`를 선택할 수 있도록 하는 `annotation` 이다.
- 사용법
	- `value = {...<T extends AuthGuard> T.class}`
	- `args = {...String}`
		- 주입할 인자가 없을 경우 입력하지 않고 `@Guard(RoleGuard.class)` 와 같이 사용해도 된다.
```Java
@Guard(value = RoleGuard.class, args = {"ADMIN"})  
public ResponseEntity<UserResDto> getById(@PathVariable("id") Long id)  
	throws NotFoundException {  
	return ResponseEntity.ok(userService.getById(id));  
}
```
### @UseGuards
- Controller 에서 사용자가 request 이전에 인증 / 인가 과정에 사용할 `Guard`를 **여러 개** 선택할 수 있도록 하는 `annotation` 이다.
	- **Guard를 여러개 사용하는 것과 다르지는 않다.**
- 사용법
	- `value = {...Guard.class}`
	- `args = {...String.class}`
```Java
@UseGuards({  
	@Guard(JwtGuard.class),  
	@Guard(value = RoleGuard.class, args = {"ADMIN"})  
})
public ResponseEntity<UserResDto> getById(@PathVariable("id") Long id)  
	throws NotFoundException {  
	return ResponseEntity.ok(userService.getById(id));  
}
```
### AuthGuard
- `AuthGuard` 는 `UseGuard` 에서 사용할 `Guard`의 기틀이 되는 `abstract class` 이다.
- 해당 클래스는 `AuthStrategy` 를 `private member` 로 가지고 있으며, 이를 상속하는 모든 `Guard` 객체는 `super(strategy)` 를 통해 해당 `Guard`가 사용하는 `Strategy`를 결정한다.
	- `AuthStrategy` 를 통해서 직접 사용할 수 있으나 다음과 같이 구현한 이유는 아래와 같다.
		- `Guard` 의 경우 어떤 형태의 `Auth` 과정의 `Guard`를 적용함을 의미한다.
		- 예를 들어, 유저의 로그인 가능 여부를 묻는 인증 과정이라고 하자. 해당 인증 과정에는 JWT 를 사용한 전략이 사용될 수도 있고, `Session` 을 통한 전략이 사용될 수도 있다. 혹은 또 다른 전략이 선택될 수도 있다. 
		- 전략이 변경된 경우에도, 해당` Guard`의 역할은 로그인 검증일 뿐이므로, 바뀌지 않는다. 따라서 단순히 해당 유저를 검증하는 전략만 변경함으로써 코드의 단 한부분만 변경하여 해당 전략의 변경이 가능하다.
		- 만약 그렇지 않다면, `@UseGuards({JwtStrategy.class})` 라고 작성된 모든 method를 변경해야할 것이다.
- 해당 클래스를 구현하는 객체는 `@Component` 를 통해 `Spring bean` 으로 등록되어야한다. `GuardResolver` 에서 해당 객체들을 스캔하여 가지고 있어야한다. 
- 사용법
```Java
@Component  
public class RoleGuard extends AuthGuard {  
	  
	public RoleGuard(@Autowired RoleStrategy strategy) {  
		super(strategy);  
	}  
}
```

### AuthStrategy
- `AuthStrategy` 는 사용자가 정의할 `Strategy`의 기틀이 되는 `interface` 이다. 
	- 보다 유연하게 전략을 선택하여 Guard를 정의하도록 하였다.
- 해당 `interface` 는 `AuthGuard` 에 주입될 객체를 정의하며, `implements` 하는 `class` 는 `public void check(HttpServletRequest request, String... args)` 를 정의해야한다.
- 이후 해당 전략을 사용하기 위해서는 `AuthGuard` 를 상속한 객체에서 `super(new CustomStrategy())`와 같은 구문을 통해 적용이 필요하다.
- 사용법
```Java
@Component  
public class RoleStrategy implements AuthStrategy {  
	@Override  
	public void check(HttpServletRequest request, String[] args) {  
	// role check  
	}  
}
```
### GuardAspect
- `@UseGuards` 를 핸들링하기 위한 `ApectJ`를 사용하는 `class`이다.  `handleUseGuards()` 를 통해 해당 `annotation` 을 선언한 메소드가 실행되기 이전에 `Guard` 의 `Strategy` 를 실행한다.
- `GuardAspect` 의 경우 `GuardResolver` 를 통해 `Guard` 객체를 찾아낸다.
### GuardResolver
- `Spring Bean` 으로 등록된 객체 중 `AuthGuard` 타입의 객체를 찾아 저장하고, 이를 이후에 `GuardAspect` 에 전달하는 역할을 수행한다.
## UserData
- `Guard` 를 통해서 `Session` 혹은 `JWT` 정보를 가져올 수 있다. 해당 경우를 위한 지원으로 `HttpServletRequest` 객체를 통해서 유저의 데이터를 `parameter` 를 통해 주입하는 역할을 수행하는 `annotation` 이 필요하다. 
### @UserData
- `Guard` 에서 주입된 정보를 사용하며, 이 정보는 `HttpServletRequest` 의 `USER_DATA` attribute 를 기본으로 한다. 만약 다른 형태의 attribute 를 사용하고자 하는 경우, `@UserData `의 `value` 값을 지정해야한다.
	- 해당 값은 외부 `Configure` 을 통한 주입을 추천하며, `HttpServletRequest` 의 `attribute` 와 겹치지 않도록해야한다. `SNAKE_CASE(UPPER CASE)` 를 추천한다.
#### 예시
- Guard
```Java
@Component  
public class JwtStrategy implements AuthStrategy {  
	@Value("jwt.data.name")  
	private String dataName = "JWT_DATA";  
	  
	@Override  
	public void check(HttpServletRequest request, String... args) {
		String token = getTokenFromRequest(request);
		request.setAttribute(dataName, token);  

	}  
	  
	private String getTokenFromRequest(@NonNull HttpServletRequest request) {  
		// Get Bearer token from authorization  
		return request.getHeader(HttpHeaders.AUTHORIZATION);  
	}  
}
```

- UserData 적용
```Java
// controller code
@Value("jwt.data.name")
private String jwtDataName;

//...

@GetMapping("/{id}")
public boolean someMethod(
	@PathVariable("id") Long id,  
	@UserData(jwtDataName) String token, // token is injected
	@UserData JwtData data // value 없이도 가능. default "USER_DATA" 사용.
	) throws NotFoundException {
	return ResponseEntity.ok(userService.getById(id, token));  
}
```
### UserDataAspect
- `@UserData`  를 핸들링하기 위한 `ApectJ`를 사용하는 `class`이다.  `handleUserData()` 를 통해 해당 `annotation` 을 선언한 `parameter` 값에 해당 `Object` 를 주입한다.
- **해당 annotation을 사용할 때 반드시 Strategy에서 사용하는 타입과 일치해야한다.**


## JWT
JWT 의 경우 `auth0:java-jwt` 라이브러리를 활용하였다. 

### JwtConfigure
- Spring Bean 으로, 외부 변수를 주입하기 위함이다.
	- `jwt.data.name`
		- `@UserData` 에 저장할 `request` 의 `attribute` 이름을 지정함.
	- `jwt.secret`
		- JWT secret 지정.
### JwtUtil
- SpringBean (Configure 사용 및 타 Bean 에서 autowire 사용을 위함.) 으로, JWT 토큰 획득 과정과 관련된 method를 담는다.
- `verifyTokenFromRequestAuthorizationHeader`
	- `HttpServletRequest` 로 부터 `Bearer Token` 을 획득하고, 이를 `JwtData` 형태로 변환한다.
- 이후 다른 형태로 JWT 가 필요할 경우, 해당 형태로 가져와서 사용할 수 있도록 method를 추가할 것이다.