### PR TITLE
FEAT: CustomException 도입 #20 #13

### DIFF
--- a/src/main/java/com/ticketwar/ticketwar/exception/ExceptionStatus.java
+++ b/src/main/java/com/ticketwar/ticketwar/exception/ExceptionStatus.java
@@ -5,7 +5,11 @@ import org.springframework.http.HttpStatus;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExceptionStatus {
+  DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+  DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+  ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
+  TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 티켓입니다."),
   ;
 
   private final int code;

--- a/src/main/java/com/ticketwar/ticketwar/user/service/UserService.java
+++ b/src/main/java/com/ticketwar/ticketwar/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.ticketwar.ticketwar.user.service;
 
+import com.ticketwar.ticketwar.exception.CustomException;
+import com.ticketwar.ticketwar.exception.ExceptionStatus;
 import com.ticketwar.ticketwar.user.dto.UserReqDto;
 import com.ticketwar.ticketwar.user.dto.UserResDto;
 import com.ticketwar.ticketwar.user.entity.User;
@@ -17,57 +19,53 @@ public class UserService {
   private final UserRepository userRepository;
   private final UserMapper userMapper;
 
-  public UserService(UserQueryService userQueryService,
-      UserRepository userRepository) {
+  public UserService(UserQueryService userQueryService, UserRepository userRepository) {
     this.userQueryService = userQueryService;
     this.userRepository = userRepository;
     this.userMapper = new UserMapper();
   }
 
   /**
-   * 회원가입시 로직
-   * NOTE: 이후 return value 조정이 필요함.
+   * 회원가입시 로직 NOTE: 이후 return value 조정이 필요함.
    *
    * @param userReqDto
    * @return User
-   * @throws BadRequestException
+   * @throws CustomException
    */
   @Transactional
-  public User signUp(UserReqDto userReqDto) throws BadRequestException {
+  public User signUp(UserReqDto userReqDto) throws CustomException {
     final String nickname = userReqDto.getNickname();
     final String email = userReqDto.getEmail();
 
     if (userQueryService.isDuplicateNickname(nickname)) {
-      throw new BadRequestException("Duplicated nickname");
+      throw new CustomException(ExceptionStatus.DUPLICATE_NICKNAME);
     }
     if (userQueryService.isDuplicateEmail(email)) {
-      throw new BadRequestException("Duplicated email");
+      throw new CustomException(ExceptionStatus.DUPLICATE_EMAIL);
     }
     return userRepository.save(userReqDto.toEntity());
   }
 
   /**
-   * 회원 정보 업데이트.
-   * NOTE: 이후 Return value 변경 필요함.
+   * 회원 정보 업데이트. NOTE: 이후 Return value 변경 필요함.
    *
    * @param id
    * @param userReqDto
    * @return
-   * @throws BadRequestException
+   * @throws CustomException
    */
   @Transactional
   public User update(Long id, UserReqDto userReqDto) throws BadRequestException {
-    final User user = userRepository.findById(id)
-                                    .orElseThrow(() -> new BadRequestException(
-                                        "Not exist user id"));
+    final User user =
+        userRepository.findById(id).orElseThrow(() -> new BadRequestException("Not exist user id"));
     final String updateNickname = userReqDto.getNickname();
     final String updateEmail = userReqDto.getEmail();
 
     if (userQueryService.isDuplicateNickname(id, updateNickname)) {
-      throw new BadRequestException("Duplicated nickname");
+      throw new CustomException(ExceptionStatus.DUPLICATE_NICKNAME);
     }
     if (userQueryService.isDuplicateEmail(id, updateEmail)) {
-      throw new BadRequestException("Duplicated email");
+      throw new CustomException(ExceptionStatus.DUPLICATE_EMAIL);
     }
     user.setNickname(updateNickname);
     user.setEmail(updateEmail);
@@ -79,12 +77,13 @@ public class UserService {
    *
    * @param id
    * @return
-   * @throws NotFoundException
+   * @throws CustomException
    */
-  public UserResDto getById(Long id) throws NotFoundException {
-    return userRepository.findById(id)
-                         .map(userMapper::mapToResDto)
-                         .orElseThrow(NotFoundException::new);
+  public UserResDto getById(Long id) throws CustomException {
+    return userRepository
+        .findById(id)
+        .map(userMapper::mapToResDto)
+        .orElseThrow(() -> new CustomException(ExceptionStatus.USER_NOT_FOUND));
   }
 
   /**
@@ -92,12 +91,13 @@ public class UserService {
    *
    * @param nickname
    * @return
-   * @throws NotFoundException
+   * @throws CustomException
    */
-  public UserResDto getByNickname(String nickname) throws NotFoundException {
-    return userRepository.findByNickname(nickname)
-                         .map(userMapper::mapToResDto)
-                         .orElseThrow(NotFoundException::new);
+  public UserResDto getByNickname(String nickname) throws CustomException {
+    return userRepository
+        .findByNickname(nickname)
+        .map(userMapper::mapToResDto)
+        .orElseThrow(() -> new CustomException(ExceptionStatus.USER_NOT_FOUND));
   }
 
   /**
@@ -105,11 +105,12 @@ public class UserService {
    *
    * @param email
    * @return
-   * @throws NotFoundException
+   * @throws CustomException
    */
-  public UserResDto getByEmail(String email) throws NotFoundException {
-    return userRepository.findByEmail(email)
-                         .map(userMapper::mapToResDto)
-                         .orElseThrow(NotFoundException::new);
+  public UserResDto getByEmail(String email) throws CustomException {
+    return userRepository
+        .findByEmail(email)
+        .map(userMapper::mapToResDto)
+        .orElseThrow(() -> new CustomException(ExceptionStatus.USER_NOT_FOUND));
   }
 }

--- a/src/test/java/com/ticketwar/ticketwar/user/service/UserServiceTest.java
+++ b/src/test/java/com/ticketwar/ticketwar/user/service/UserServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
+import com.ticketwar.ticketwar.exception.CustomException;
 import com.ticketwar.ticketwar.user.dto.UserReqDto;
 import com.ticketwar.ticketwar.user.dto.UserResDto;
 import com.ticketwar.ticketwar.user.entity.User;
@@ -82,7 +83,7 @@ class UserServiceTest {
                                      .build();
       BDDMockito.given(queryService.isDuplicateNickname(any(String.class))).willReturn(true);
       // when, then
-      assertThrows(BadRequestException.class, () -> service.signUp(request));
+      assertThrows(CustomException.class, () -> service.signUp(request));
     }
 
     @DisplayName("실패 - 이메일 중복")
@@ -96,7 +97,7 @@ class UserServiceTest {
       BDDMockito.given(queryService.isDuplicateNickname(any(String.class))).willReturn(false);
       BDDMockito.given(queryService.isDuplicateEmail(any(String.class))).willReturn(true);
       // when, then
-      assertThrows(BadRequestException.class, () -> service.signUp(request));
+      assertThrows(CustomException.class, () -> service.signUp(request));
     }
 
   }
@@ -160,7 +161,7 @@ class UserServiceTest {
                 .willReturn(false);
       BDDMockito.given(repository.save(any(User.class))).willReturn(expect);
       // when then
-      assertThrows(BadRequestException.class, () -> service.update(1L, request));
+      assertThrows(CustomException.class, () -> service.update(1L, request));
     }
 
     @Test
@@ -188,7 +189,7 @@ class UserServiceTest {
                 .willReturn(true);
       BDDMockito.given(repository.save(any(User.class))).willReturn(expect);
       // when then
-      assertThrows(BadRequestException.class, () -> service.update(1L, request));
+      assertThrows(CustomException.class, () -> service.update(1L, request));
     }
 
   }
@@ -240,7 +241,7 @@ class UserServiceTest {
       BDDMockito.given(repository.findById(any(Long.class))).willReturn(Optional.empty());
       BDDMockito.given(mapper.mapToResDto(any(User.class))).willReturn(expected);
       // when
-      assertThrows(NotFoundException.class, () -> service.getById(999L));
+      assertThrows(CustomException.class, () -> service.getById(999L));
     }
   }
 
@@ -293,7 +294,7 @@ class UserServiceTest {
       BDDMockito.given(repository.findByNickname(any(String.class))).willReturn(Optional.empty());
       BDDMockito.given(mapper.mapToResDto(any(User.class))).willReturn(expected);
       // when
-      assertThrows(NotFoundException.class, () -> service.getByNickname("None"));
+      assertThrows(CustomException.class, () -> service.getByNickname("None"));
     }
   }
 
@@ -346,7 +347,7 @@ class UserServiceTest {
       BDDMockito.given(repository.findByEmail(any(String.class))).willReturn(Optional.empty());
       BDDMockito.given(mapper.mapToResDto(any(User.class))).willReturn(expected);
       // when
-      assertThrows(NotFoundException.class, () -> service.getByEmail("None"));
+      assertThrows(CustomException.class, () -> service.getByEmail("None"));
     }
   }
 }

--- a/src/test/java/com/ticketwar/ticketwar/user/service/UserServiceTest.java
+++ b/src/test/java/com/ticketwar/ticketwar/user/service/UserServiceTest.java
@@ -13,7 +13,6 @@ import com.ticketwar.ticketwar.user.repository.UserRepository;
 import com.ticketwar.ticketwar.user.utils.UserMapper;
 import jakarta.transaction.Transactional;
 import java.util.Optional;
-import org.apache.coyote.BadRequestException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -25,8 +24,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
-
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)


### PR DESCRIPTION
# 작업파일
- ExceptionStatus
- UserService
- UserServiceTest

## ExceptionStatus
- enum에 새로운 예외를 추가했습니다.
```JAVA
 DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
  DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
  ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
  TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 티켓입니다."),
  ```
  ## UserServie
  - 기존 Exception을 CustomException으로 교체했습니다.
  - 주석의 throws를 CutomException으로 교체하였습니다.
  - 메소드의 throws를 CustomException으로 교체하였습니다.

## UserServiceTest
- AsrretThrows() 의 기대 Exception을 CustomException으로 교체하였습니다.
- 테스트 정상적으로 실행되는부분 확인했습니다.

### 이슈
#20
#13 